### PR TITLE
only break words if necessary

### DIFF
--- a/acnh.css
+++ b/acnh.css
@@ -146,7 +146,7 @@
 
 .container p, .container h2 {
   color: white;
-  word-break: break-all;
+  overflow-wrap: break-word;
   text-align: center;
 }
 


### PR DESCRIPTION
First of all, thank you for maintaining this site! I've been using it for quite some time now, and I'm just two items away from completing my museum thanks to it.

This is one half of a userstyle I've been using. While `word-break: break-all` will look for *any* opportunity to break words, `overflow-wrap: anywhere` or `overflow-wrap: break-word` will only break words if the whole word cannot be placed on its own line. (The difference between the two is irrelevant in this case, but you can learn more [here](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) if you want!)

This improvement is particularly noticeable on the art list, where descriptions no longer have unnecessary word breaks:

`word-break: break-all` | `overflow-wrap: break-word`
--- | ---
![image](https://user-images.githubusercontent.com/28949509/159355717-9ecb140e-4b9f-4e73-bf66-4db48b5d7ff6.png) | ![image](https://user-images.githubusercontent.com/28949509/159355853-2ba4adcb-7c46-4bc3-8642-6e0dfa9d470c.png)
![image](https://user-images.githubusercontent.com/28949509/159355947-41907fcf-e09e-47cc-8aa9-c67858cd76b8.png) | ![image](https://user-images.githubusercontent.com/28949509/159356013-84072fa3-a57e-48a2-a2ad-5a6c873c8453.png)
