### PR TITLE
space subcontainers evenly

### DIFF
--- a/acnh.css
+++ b/acnh.css
@@ -98,7 +98,7 @@
 
 .main-container {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-evenly;
   flex-wrap: wrap;
   margin: 0 30px;
 }


### PR DESCRIPTION
This is the other (and potentially more contentious) half of the userstyle I've been using.

It spaces children of `.main-container` evenly. This results in less space being put between items when there are not enough visible results to fill a row, and centers a result if it is the only one visible.

`justify-content: space-between` | `justify-content: space-evenly`
--- | ---
![image](https://user-images.githubusercontent.com/28949509/159358716-bcc83a9c-7e97-4320-8d33-6371bdce8991.png) | ![image](https://user-images.githubusercontent.com/28949509/159358770-a48fd7ed-d393-4e61-adcc-21217fa16bc6.png)
![image](https://user-images.githubusercontent.com/28949509/159358931-6a6c8efc-f68d-411b-8e26-ab5d9e8461f6.png) | ![image](https://user-images.githubusercontent.com/28949509/159359032-0aeebadc-9dbf-4327-bae7-c61d2d408140.png)
![image](https://user-images.githubusercontent.com/28949509/159359099-27a73843-d72d-4724-8501-2a40b979500c.png) | ![image](https://user-images.githubusercontent.com/28949509/159359121-c0fcea9a-5a0c-400c-b47e-44412e59ba93.png)
